### PR TITLE
fix: apply button + viewport accumulation

### DIFF
--- a/emoji-map/Views/Home/Home.swift
+++ b/emoji-map/Views/Home/Home.swift
@@ -20,6 +20,23 @@ struct Home: View {
     // ViewModel
     @StateObject private var viewModel: HomeViewModel
     
+    // Computed property to determine which places list to display
+    private var placesToDisplay: [Place] {
+        // If we have network-dependent filters, use filteredPlaces
+        if viewModel.hasNetworkDependentFilters {
+            logger.notice("Using filteredPlaces list for display (network-dependent filters active)")
+            return viewModel.filteredPlaces
+        } else if viewModel.showFavoritesOnly || (viewModel.minimumRating > 0 && viewModel.useLocalRatings) {
+            // If we have local-only filters (favorites or local ratings), use filteredPlaces
+            logger.notice("Using filteredPlaces list for display (local filters active)")
+            return viewModel.filteredPlaces
+        } else {
+            // If no filters are active, use the regular places list
+            logger.notice("Using regular places list for display (no filters active)")
+            return viewModel.places
+        }
+    }
+    
     // MARK: - Initialization
     
     init() {
@@ -33,8 +50,8 @@ struct Home: View {
             Map(position: $position) {
                 UserAnnotation()
                 
-                // Display place annotations - use filteredPlaces instead of places
-                ForEach(viewModel.filteredPlaces) { place in
+                // Display place annotations - use placesToDisplay computed property
+                ForEach(placesToDisplay) { place in
                     place.mapAnnotation(onTap: { selectedPlace in
                         viewModel.selectPlace(selectedPlace)
                     })


### PR DESCRIPTION
This pull request introduces several changes to the `HomeViewModel` and `FilterView` classes in the `emoji-map` project, primarily focusing on handling network-dependent filters and improving the filtering logic. The most important changes include adding a computed property for network-dependent filters, updating the filtering logic to handle these filters, and improving the initialization and state management in the `FilterView`.

### Improvements to filtering logic:

* [`emoji-map/ViewModels/HomeViewModel.swift`](diffhunk://#diff-94cba863428c160b58a32ccc8dc66b9969f717a980d9d20db463c4f09c01ec51R73-R86): Added a computed property `hasNetworkDependentFilters` to check for filters that require network requests. Updated various methods to handle network-dependent filters by fetching filtered places when necessary. [[1]](diffhunk://#diff-94cba863428c160b58a32ccc8dc66b9969f717a980d9d20db463c4f09c01ec51R73-R86) [[2]](diffhunk://#diff-94cba863428c160b58a32ccc8dc66b9969f717a980d9d20db463c4f09c01ec51R283-R288) [[3]](diffhunk://#diff-94cba863428c160b58a32ccc8dc66b9969f717a980d9d20db463c4f09c01ec51R427-R430) [[4]](diffhunk://#diff-94cba863428c160b58a32ccc8dc66b9969f717a980d9d20db463c4f09c01ec51R447-R454) [[5]](diffhunk://#diff-94cba863428c160b58a32ccc8dc66b9969f717a980d9d20db463c4f09c01ec51L474-R507) [[6]](diffhunk://#diff-94cba863428c160b58a32ccc8dc66b9969f717a980d9d20db463c4f09c01ec51L539-R574) [[7]](diffhunk://#diff-94cba863428c160b58a32ccc8dc66b9969f717a980d9d20db463c4f09c01ec51L634-R675)

* [`emoji-map/ViewModels/HomeViewModel.swift`](diffhunk://#diff-94cba863428c160b58a32ccc8dc66b9969f717a980d9d20db463c4f09c01ec51R773-R796): Introduced a method `mergeFilteredPlaces` to merge new filtered places with existing ones, avoiding duplicates.

### Updates to `FilterView`:

* [`emoji-map/Views/FiltersSheet/FilterView.swift`](diffhunk://#diff-3df49969017200ba24a907e110cc8585ccfb6c3c39a386b42e27230a1aa74ffcR70-R71): Added state tracking for the initial value of the "Open Now" filter to detect changes. [[1]](diffhunk://#diff-3df49969017200ba24a907e110cc8585ccfb6c3c39a386b42e27230a1aa74ffcR70-R71) [[2]](diffhunk://#diff-3df49969017200ba24a907e110cc8585ccfb6c3c39a386b42e27230a1aa74ffcL100-R102)

* [`emoji-map/Views/FiltersSheet/FilterView.swift`](diffhunk://#diff-3df49969017200ba24a907e110cc8585ccfb6c3c39a386b42e27230a1aa74ffcL136-R159): Improved the initialization logic to log the view model's price levels and handle cases where no price levels are selected.

* [`emoji-map/Views/FiltersSheet/FilterView.swift`](diffhunk://#diff-3df49969017200ba24a907e110cc8585ccfb6c3c39a386b42e27230a1aa74ffcR388-R392): Updated the `applyFilters` method to treat no selected price levels as all price levels selected. [[1]](diffhunk://#diff-3df49969017200ba24a907e110cc8585ccfb6c3c39a386b42e27230a1aa74ffcR388-R392) [[2]](diffhunk://#diff-3df49969017200ba24a907e110cc8585ccfb6c3c39a386b42e27230a1aa74ffcL392-R406)

### Display logic in `Home` view:

* [`emoji-map/Views/Home/Home.swift`](diffhunk://#diff-a4d25cef94bf8bb1f71e2d443c47b2c86481b26152c166be42aeb3dda60b6219R23-R39): Added a computed property `placesToDisplay` to determine which list of places to display based on the active filters. Updated the map annotations to use this computed property. [[1]](diffhunk://#diff-a4d25cef94bf8bb1f71e2d443c47b2c86481b26152c166be42aeb3dda60b6219R23-R39) [[2]](diffhunk://#diff-a4d25cef94bf8bb1f71e2d443c47b2c86481b26152c166be42aeb3dda60b6219L36-R54)